### PR TITLE
Hardening: PEP 621 packaging, CI test gate, logging migration (v0.3.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,25 @@ on:
       - 'pyproject.toml'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run test suite
+        run: python -m pytest tests/ -v
+
   check-version:
     runs-on: ubuntu-latest
     outputs:
@@ -17,19 +36,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Check if version changed
         id: check
         run: |
           python3 << 'EOF'
-          import re, urllib.request, json, os
+          import tomllib, urllib.request, json, os
 
-          # Extract version from setup.py
-          with open("setup.py") as f:
-              match = re.search(r"version=['\"]([^'\"]+)['\"]", f.read())
-          if not match:
-              print("Could not extract version from setup.py")
-              exit(1)
-          local_version = match.group(1)
+          # Extract version from pyproject.toml (single source of truth)
+          with open("pyproject.toml", "rb") as f:
+              local_version = tomllib.load(f)["project"]["version"]
 
           # Query PyPI for the latest published version
           try:
@@ -56,7 +75,7 @@ jobs:
           EOF
 
   publish:
-    needs: check-version
+    needs: [test, check-version]
     if: needs.check-version.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, desarrollo]
+  pull_request:
+    branches: [main, desarrollo]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run test suite
+        run: python -m pytest tests/ -v

--- a/instantneo/__init__.py
+++ b/instantneo/__init__.py
@@ -71,6 +71,22 @@ Otras piezas (importables vía subpackage, no top-level por minimalismo):
 Documentación de diseño: ``docs/design/`` (5 documentos).
 """
 
+# ── Versión (fuente única: pyproject.toml) ──────────────────────────
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("instantneo")
+except PackageNotFoundError:  # ejecutando desde el source sin instalar
+    __version__ = "0.0.0.dev0"
+
+# ── Logging ─────────────────────────────────────────────────────────
+# Patrón estándar de librería: adjuntamos un NullHandler para no emitir
+# nada por default. La app consumidora decide handlers/niveles, p.ej.
+# logging.getLogger("instantneo").setLevel(logging.DEBUG).
+import logging as _logging
+
+_logging.getLogger(__name__).addHandler(_logging.NullHandler())
+
 # ── Core (clásico) ──────────────────────────────────────────────────
 from .core import InstantNeo
 from .models.run_info import RunInfo
@@ -137,6 +153,7 @@ class Adapters:
 
 # Public surface
 __all__ = [
+    "__version__",
     # Core (clásico)
     "InstantNeo", "RunInfo",
     "tool", "AgentCapabilities", "CapabilitiesOperations",

--- a/instantneo/core.py
+++ b/instantneo/core.py
@@ -2,9 +2,12 @@ from dataclasses import dataclass, field
 from typing import List, Dict, Any, Callable, Optional, Union, Generator, Type, AsyncGenerator
 import asyncio
 import json
+import logging
 import time
 import threading
 from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
 from instantneo.skills.agent_capabilities import AgentCapabilities
 from instantneo.skills.agent_capabilities import AgentCapabilities as SkillManager  # backward compat
 from instantneo.models.run_info import RunInfo, LLMCall, ToolExecution, SkillExecution
@@ -657,14 +660,13 @@ Args:
                 if tool_info and 'parameters' in tool_info:
                     formatted_tools.append(format_tool(tool_info))
                 else:
-                    print(f"Warning: Tool '{name}' is missing metadata or 'parameters'. Skipping.")
+                    logger.warning("Tool '%s' is missing metadata or 'parameters'. Skipping.", name)
 
             if formatted_tools:
                 adapter_params.additional_params['tools'] = formatted_tools
                 if 'tool_choice' in run_params.additional_params:
                     adapter_params.additional_params['tool_choice'] = run_params.additional_params['tool_choice']
 
-        #print("Adapter params:", json.dumps(adapter_params.to_dict(), indent=2))
 
         # Create RunInfo to capture metadata
         run_info = RunInfo(
@@ -717,7 +719,7 @@ Args:
             if tool_func:
                 active_tools[tool_name] = tool_func
             else:
-                print(f"Warning: Tool '{tool_name}' not found in AgentCapabilities.")
+                logger.warning("Tool '%s' not found in AgentCapabilities.", tool_name)
 
         return active_tools
 
@@ -825,7 +827,7 @@ Args:
         reasoning = getattr(message, 'reasoning', None)
 
         if tool_calls:
-            print(f'{"*" * 40}\n* {"I am using my skills. Wait for it...":^36} *\n{"*" * 40}\n')
+            logger.debug("Executing %d tool call(s)", len(tool_calls))
             results = self._handle_tool_calls(tool_calls, execution_mode, run_info)
             result = {
                 "text": content if content else None,
@@ -843,7 +845,6 @@ Args:
         """Handle tool calls from the language model."""
         results = []
         futures = []  # Para almacenar futures en caso de ejecución asíncrona
-        #print(f"DEBUG: Valor de self.async_execution en _handle_tool_calls: {self.async_execution}")
 
         for tool_call in tool_calls:
             if tool_call.type == 'function':
@@ -855,7 +856,6 @@ Args:
                 # (ver `_chat_completions._normalize_tool_arguments`),
                 # esto es cinturón de seguridad para otras rutas.
                 function_args = json.loads(tool_call.function.arguments) or {}
-                #print(f"Llamando a la función: {function_name} con argumentos: {function_args}")
 
                 if function_name in self.get_tool_names():
                     tool_func = self.get_tool_by_name(function_name)
@@ -904,7 +904,7 @@ Args:
                     if run_info:
                         run_info.tool_executions.append(tool_exec)
                 else:
-                    print(f"Warning: Tool '{function_name}' not found in available tools.")
+                    logger.warning("Tool '%s' not found in available tools.", function_name)
 
         # Si estamos en modo WAIT_RESPONSE y async_execution=True, ejecutamos todas las corrutinas
         # de manera síncrona para esperar los resultados
@@ -926,10 +926,8 @@ Args:
                 else:
                     # Si el loop no está corriendo, simplemente ejecutamos gather
                     results = loop.run_until_complete(asyncio.gather(*results))
-
-                #print(f"Resultados de ejecución asíncrona: {results}")
-            except Exception as e:
-                print(f"Error al ejecutar corrutinas de manera asíncrona: {e}")
+            except Exception:
+                logger.exception("Error al ejecutar corrutinas de manera asíncrona")
 
         # Si estamos en modo EXECUTION_ONLY y async_execution=True, esperamos a que terminen las ejecuciones
         if execution_mode == self.EXECUTION_ONLY and self.async_execution and futures:
@@ -947,7 +945,7 @@ Args:
                 else:
                     loop.run_until_complete(asyncio.gather(*futures))
             except Exception as e:
-                print(f"Error al ejecutar corrutinas en modo EXECUTION_ONLY: {e}")
+                logger.exception("Error al ejecutar corrutinas en modo EXECUTION_ONLY")
 
         if execution_mode == self.EXECUTION_ONLY:
             return "Todas las funciones se han ejecutado en segundo plano."
@@ -1081,7 +1079,7 @@ Args:
                         yield str(chunk)
             except Exception as e:
                 run_info.error = str(e)
-                print(f"Error inesperado: {e}")
+                logger.exception("Error inesperado durante el streaming")
 
         # Store accumulated reasoning in run_info
         llm_call.reasoning_content = accumulated_reasoning if accumulated_reasoning else None
@@ -1136,7 +1134,7 @@ Args:
                         else:
                             loop.run_until_complete(asyncio.gather(*futures))
                     except Exception as e:
-                        print(f"Error al ejecutar corrutinas en streaming: {e}")
+                        logger.exception("Error al ejecutar corrutinas en streaming")
 
                 yield {
                     "text": full_response if full_response else None,
@@ -1158,7 +1156,6 @@ Args:
                 }
             elif execution_mode == self.WAIT_RESPONSE and tool_calls:
                 # Para WAIT_RESPONSE, ejecutamos las herramientas y devolvemos los resultados
-                #print(f"DEBUG: En streaming, procesando herramientas en modo WAIT_RESPONSE con async_execution={self.async_execution}")
                 results = []
                 futures = []
 
@@ -1192,7 +1189,7 @@ Args:
                                 except Exception as e:
                                     tool_exec.exception = str(e)
                         else:
-                            print(f"Warning: Tool '{function_name}' not found in available tools.")
+                            logger.warning("Tool '%s' not found in available tools.", function_name)
 
                         run_info.tool_executions.append(tool_exec)
 
@@ -1214,10 +1211,8 @@ Args:
                         else:
                             results = loop.run_until_complete(
                                 asyncio.gather(*futures))
-
-                        #print(f"Resultados de ejecución asíncrona en streaming: {results}")
                     except Exception as e:
-                        print(f"Error al ejecutar corrutinas en streaming con WAIT_RESPONSE: {e}")
+                        logger.exception("Error al ejecutar corrutinas en streaming con WAIT_RESPONSE")
 
 
                 # Devolvemos los resultados

--- a/instantneo/skills/agent_capabilities.py
+++ b/instantneo/skills/agent_capabilities.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import logging
 import pkgutil
 import importlib
 import importlib.util
@@ -10,6 +11,8 @@ from pathlib import Path
 
 from .agent_skill import AgentSkill
 from .skill_md_parser import SkillMdParser
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -89,7 +92,7 @@ class CapabilityLoader:
                     name = self.from_skill_folder(str(folder))
                     loaded.append(name)
                 except Exception as e:
-                    print(f"Error cargando {folder}: {e}")
+                    logger.exception("Error cargando %s", folder)
 
         return loaded
 
@@ -213,9 +216,13 @@ class AgentCapabilities:
             if simple_name not in self.duplicates:
                 self.duplicates[simple_name] = []
             self.duplicates[simple_name].append(func)
-            print(f"Advertencia: La tool '{simple_name}' ya fue registrada en "
-                  f"{self.registry_by_name[simple_name][0].__code__.co_filename}. "
-                  f"La definición en {file_path} se ha agregado al registro de duplicados.")
+            logger.warning(
+                "La tool '%s' ya fue registrada en %s. La definición en %s "
+                "se ha agregado al registro de duplicados.",
+                simple_name,
+                self.registry_by_name[simple_name][0].__code__.co_filename,
+                file_path,
+            )
         else:
             self.registry_by_name[simple_name] = [func]
 
@@ -293,7 +300,7 @@ class AgentCapabilities:
                     self._load_tools_from_module(module, metadata_filter)
                     del sys.modules[module_name]
                 except Exception as e:
-                    print(f"Error al cargar el archivo {file_path}: {e}")
+                    logger.exception("Error al cargar el archivo %s", file_path)
 
         return f"Tools Loaded:{self.get_tool_names()} from {folder_path}"
 
@@ -417,7 +424,7 @@ class AgentCapabilities:
                 self.registry_by_name.pop(name, None)
                 return True
             else:
-                print(f"Advertencia: Existen múltiples tools con el nombre '{name}'. Especifica el módulo para eliminar.")
+                logger.warning("Existen múltiples tools con el nombre '%s'. Especifica el módulo para eliminar.", name)
                 return False
 
     # Backward compat alias
@@ -514,7 +521,7 @@ class AgentCapabilities:
                         loaded = self._load_tools_from_file(str(full_path))
                         result["skills_loaded"].extend(loaded)
                     except Exception as e:
-                        print(f"Error cargando tools de {file_path}: {e}")
+                        logger.exception("Error cargando tools de %s", file_path)
 
         elif item_type == "manager":
             result["description"] = item.description or ""

--- a/instantneo/skills/skill_md_parser.py
+++ b/instantneo/skills/skill_md_parser.py
@@ -7,12 +7,15 @@ El formato SKILL.md consiste en:
 - Body en Markdown con instrucciones
 """
 
+import logging
 import re
 import yaml
 from pathlib import Path
 from typing import List, Dict, Optional, Any
 
 from .agent_skill import AgentSkill
+
+logger = logging.getLogger(__name__)
 
 
 class SkillMdParser:
@@ -153,7 +156,7 @@ class SkillMdParser:
                                     "path": str(folder),
                                     "type": "skill_folder"
                                 })
-                    except Exception as e:
-                        print(f"Error parseando {folder}: {e}")
+                    except Exception:
+                        logger.exception("Error parseando %s", folder)
 
         return discoveries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,46 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "instantneo"
+version = "0.3.0"
+description = "Framework para construir agentes con LLMs, con control granular y composición simple."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+authors = [
+    { name = "Diego Ponce de León Franco", email = "dponcedeleonf@gmail.com" },
+]
+keywords = ["llm", "agents", "ai", "openai", "anthropic", "groq", "gemini", "vertex ai"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    "docstring_parser",
+    "httpx",
+    "cryptography",
+    "pyyaml",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[project.urls]
+Homepage = "https://github.com/instantneo/instantneo"
+Source = "https://github.com/instantneo/instantneo"
+"Bug Reports" = "https://github.com/instantneo/instantneo/issues"
+
+[tool.setuptools.packages.find]
+include = ["instantneo*"]
+
+[tool.setuptools.package-data]
+instantneo = ["py.typed"]

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,9 @@
-from setuptools import setup, find_packages
+"""Shim de compatibilidad.
 
-setup(
-    name='instantneo',
-    version='0.2.1',
-    packages=find_packages(),
-    install_requires=[
-        'docstring_parser',
-        'httpx',
-        'cryptography',
-        'pyyaml',
-    ],
-    author='Diego Ponce de León Franco',
-    author_email='dponcedeleonf@gmail.com',
-    description='Framework para construir agentes con LLMs, con control granular y composición simple.',
-    long_description=open('README.md', encoding='utf-8').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/instantneo/instantneo',
-    classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.11',
-    ],
-    keywords='llm, agents, ai, openai, anthropic, groq, gemini, vertex ai',
-    project_urls={
-        'Bug Reports': 'https://github.com/instantneo/instantneo/issues',
-        'Source': 'https://github.com/instantneo/instantneo',
-    },
-)
+La metadata del proyecto vive en ``pyproject.toml`` (PEP 621). Este archivo
+solo existe para herramientas que aún invocan ``setup.py`` directamente; no
+duplica metadata.
+"""
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
## Resumen
Hardening y profesionalización del proyecto, en 3 commits separados por tema.

### chore(packaging) — PEP 621
- Metadata movida a `[project]` en `pyproject.toml`; `setup.py` reducido a shim.
- `instantneo.__version__` vía `importlib.metadata` (fuente única en pyproject).
- `instantneo/py.typed` (PEP 561) → los type checkers de consumidores respetan los tipos.
- `requires-python >=3.11`, extra `[dev]` con pytest.
- Bump 0.2.1 → **0.3.0**.

### ci — gate de tests antes de publicar
- Nuevo `test.yml`: pytest en push/PR a `main` y `desarrollo` (Python 3.11 y 3.12).
- `publish.yml`: el job `publish` ahora `needs: [test, check-version]` → un `main` rojo no publica a PyPI.
- Versión leída de `pyproject.toml` con `tomllib`.

### refactor(logging) — print → logging
- `print()` migrados a `logging` (warnings → `logger.warning`, errores → `logger.exception`).
- Eliminado el banner "I am using my skills" que ensuciaba el stdout del consumidor.
- `NullHandler` en el package logger; dead code de `#print` removido.

## Verificación
- 419/419 tests pasan; `validate.py` sin regresión.
- `pip install -e .` y `python -m build` OK; `__version__` = 0.3.0.