### PR TITLE
fix(loop): aislamiento de vistas por loop para soporte multi-loop con…

### DIFF
--- a/instantneo/loop/default_view.py
+++ b/instantneo/loop/default_view.py
@@ -192,13 +192,18 @@ def loop_default(
     *,
     show_all_runs: bool = False,
     image_policy: Literal["every_turn", "first_only", "none"] = "every_turn",
+    origin: Optional[str] = None,
 ) -> RenderedPrompt:
     """Vista default del Loop. Texto markdown + imágenes según policy.
 
     Doc: docs/design/loop-design.md sección "Implementación" (línea 690).
 
     Comportamiento de texto:
-      - Filtra por run_id actual salvo que show_all_runs=True.
+      - Si ``origin`` está set: filtra por ``content["origin"] == origin``.
+        Muestra todos los runs de ese loop. Concurrent-safe para multi-loop.
+      - Si ``show_all_runs=True``: muestra todo el History sin filtro.
+      - Default (sin origin, sin show_all_runs): filtra por run_id actual
+        (comportamiento legacy, correcto para loop único).
       - Solo incluye entries narrativas: prompt, response, tool_call.
       - Renderea reasoning del response (extended thinking) como bloque
         distinguible.
@@ -213,28 +218,69 @@ def loop_default(
         - "every_turn" (default): incluye en cada step.
         - "first_only":           solo en step 1.
         - "none":                 nunca.
-    """
-    rid = current_run_id(history)
-    entries = [
-        e for e in history.all()
-        if (show_all_runs or (
-            isinstance(e.content, dict) and e.content.get("run_id") == rid
-        ))
-        and e.type in {"prompt", "response", "tool_call"}
-    ]
 
-    cfg = current_run_config(history) or {}
+    Args:
+        origin: nombre del loop (``loop.name``). Cuando está set, filtra
+            por ``content["origin"]`` en vez de por run_id — correcto en
+            escenarios multi-loop concurrentes. El Loop lo bake-a en el
+            closure al registrar la vista, así que el user no lo pasa
+            directamente salvo en vistas custom.
+    """
+    # ── Determinar modo de filtrado ────────────────────────────────
+    if show_all_runs:
+        entries = [
+            e for e in history.all()
+            if e.type in {"prompt", "response", "tool_call"}
+        ]
+        cfg = current_run_config(history) or {}
+        current_rid = None
+        run_step_starts = history.by_type("step_start")
+
+    elif origin is not None:
+        # Multi-loop: filtrar por origin (concurrent-safe).
+        # Muestra todos los runs de este loop.
+        entries = [
+            e for e in history.all()
+            if isinstance(e.content, dict)
+            and e.content.get("origin") == origin
+            and e.type in {"prompt", "response", "tool_call"}
+        ]
+        # Para max_steps y current_step: leer del último run_start de este origin.
+        origin_run_starts = [
+            e for e in history.by_type("run_start")
+            if isinstance(e.content, dict) and e.content.get("origin") == origin
+        ]
+        cfg = origin_run_starts[-1].content if origin_run_starts else {}
+        current_rid = cfg.get("run_id")
+        run_step_starts = [
+            e for e in history.by_type("step_start")
+            if isinstance(e.content, dict)
+            and e.content.get("origin") == origin
+            and e.content.get("run_id") == current_rid
+        ]
+
+    else:
+        # Legacy: un solo loop. Filtrar por run_id actual.
+        rid = current_run_id(history)
+        entries = [
+            e for e in history.all()
+            if isinstance(e.content, dict)
+            and e.content.get("run_id") == rid
+            and e.type in {"prompt", "response", "tool_call"}
+        ]
+        cfg = current_run_config(history) or {}
+        current_rid = rid
+        run_step_starts = [
+            e for e in history.by_type("step_start")
+            if isinstance(e.content, dict) and e.content.get("run_id") == rid
+        ]
+
+    # ── Header: turno actual y máximo ─────────────────────────────
     max_steps = cfg.get("loop", {}).get("max_steps", "?")
 
-    # `current_step` representa el step que está por ejecutarse en
-    # este render. El Loop appendea `step_start` DESPUÉS de invocar la
-    # vista, así que `current_step_num` apunta al step previo (o None
-    # antes del primer step). Para reflejar el step actual contamos
-    # cuántos step_starts del run ya pasaron y sumamos 1.
-    run_step_starts = [
-        e for e in history.by_type("step_start")
-        if isinstance(e.content, dict) and e.content.get("run_id") == rid
-    ]
+    # `current_step` = step que está por ejecutarse.
+    # El Loop appendea `step_start` DESPUÉS de invocar la vista, así que
+    # contamos los step_starts ya presentes y sumamos 1.
     current_step = len(run_step_starts) + 1
 
     text = _markdown_format_default(
@@ -243,13 +289,13 @@ def loop_default(
         max_steps=max_steps,
     )
 
-    # Decidir qué imágenes incluir
+    # ── Imágenes: prompt del run actual ───────────────────────────
     images, image_detail = None, None
     prompt_entry = next(
         (e for e in entries
          if e.type == "prompt"
          and isinstance(e.content, dict)
-         and e.content.get("run_id") == rid),
+         and e.content.get("run_id") == current_rid),
         None,
     )
     if prompt_entry and prompt_entry.content.get("images"):
@@ -272,13 +318,20 @@ def loop_default(
 # Helper para registrar la vista en un History
 # ════════════════════════════════════════════════════════════════════
 
-def _build_loop_default_view() -> Callable:
-    """Devuelve una callable que el Loop registra como vista 'loop_default'.
+def _build_loop_default_view(origin: Optional[str] = None) -> Callable:
+    """Devuelve una callable que el Loop registra como vista default.
 
-    Es la versión "out-of-the-box" — usa los defaults (``show_all_runs=False``,
-    ``image_policy="every_turn"``). Si el user quiere otra configuración,
-    registra su propia vista antes de construir el Loop.
+    Cuando ``origin`` está set (caso normal — el Loop lo pasa siempre),
+    la vista resultante filtra por ese origin: concurrent-safe para
+    multi-loop. Sin origin, usa el fallback legacy por run_id.
+
+    Args:
+        origin: ``loop.name`` del Loop que registra la vista. El Loop
+            lo pasa siempre al construirse; solo es None si se llama
+            desde código externo sin loop (uso avanzado).
     """
+    if origin is not None:
+        return lambda h: loop_default(h, origin=origin)
     return loop_default
 
 

--- a/instantneo/loop/instant_loop.py
+++ b/instantneo/loop/instant_loop.py
@@ -146,8 +146,17 @@ class InstantLoop:
         self.agent = agent
         self.history = history if history is not None else History()
         self.name = name or f"loop_{uuid.uuid4().hex[:8]}"
-        self.view = view
         self.max_steps = max_steps
+
+        # Transformar "loop_default" al nombre único de este loop.
+        # Cada loop registra su propia vista con origin baked-in, evitando
+        # colisiones en multi-loop concurrente sobre el mismo History.
+        # El user siempre puede pasar view="loop_default" y obtiene el
+        # comportamiento esperado, con nombre interno "loop_default_{name}".
+        if view == "loop_default":
+            self.view = f"loop_default_{self.name}"
+        else:
+            self.view = view
         self.debug = bool(debug)
 
         # Stop signals: whitelist provista + auto del sugar
@@ -197,12 +206,24 @@ class InstantLoop:
     def _ensure_view_available(self) -> None:
         """Garantiza que ``self.view`` existe en el History.
 
-        Doc: loop-design.md líneas 199-220.
+        Para la vista default, el nombre ya fue transformado a
+        ``"loop_default_{self.name}"`` en ``__init__``. Cada loop
+        registra su propia vista con ``origin`` baked-in — sin
+        colisión entre loops que comparten el mismo History.
+
+        Para vistas custom (cualquier nombre que no empiece con
+        ``"loop_default_"``), el user es responsable de registrarlas
+        antes de construir el Loop.
         """
         if self.history.has_view(self.view):
-            return  # ya registrada por user u otro Loop sobre el mismo History
-        if self.view == "loop_default":
-            self.history.add_view("loop_default", _build_loop_default_view())
+            return  # ya registrada (este mismo loop en un run anterior)
+
+        if self.view.startswith("loop_default_"):
+            # Vista default de este loop: registrar con origin baked-in.
+            self.history.add_view(
+                self.view,
+                _build_loop_default_view(origin=self.name),
+            )
         else:
             raise LoopConfigError(
                 f"Vista '{self.view}' no registrada en el History. "

--- a/instantneo/monitor/conditions.py
+++ b/instantneo/monitor/conditions.py
@@ -52,64 +52,93 @@ def when_type_present(type: str) -> "Condition":
 # Conditions sobre la última entry
 # ════════════════════════════════════════════════════════════════════
 
-def when_last_is_type(type: str) -> "Condition":
+def when_last_is_type(type: str, origin: Optional[str] = None) -> "Condition":
     """True cuando la última entry del History tiene ese ``type``.
 
     Devuelve ``False`` si el History está vacío.
+
+    Args:
+        origin: si está set, considera solo entries con
+            ``content["origin"] == origin`` — correcto en multi-loop.
+            ``None`` (default) evalúa sobre todo el History.
     """
     def cond(history: "History") -> bool:
         entries = history.all()
+        if origin is not None:
+            entries = [e for e in entries
+                       if isinstance(e.content, dict) and e.content.get("origin") == origin]
         if not entries:
             return False
         return entries[-1].type == type
     return cond
 
 
-def when_last_is_author(author: str) -> "Condition":
+def when_last_is_author(author: str, origin: Optional[str] = None) -> "Condition":
     """True cuando la última entry del History es de ese ``author``.
 
     Devuelve ``False`` si el History está vacío.
+
+    Args:
+        origin: si está set, filtra por ``content["origin"]`` antes de
+            evaluar el author — correcto en multi-loop.
     """
     def cond(history: "History") -> bool:
         entries = history.all()
+        if origin is not None:
+            entries = [e for e in entries
+                       if isinstance(e.content, dict) and e.content.get("origin") == origin]
         if not entries:
             return False
         return entries[-1].author == author
     return cond
 
 
-def when_last_content_matches(predicate: Callable[[dict], bool]) -> "Condition":
+def when_last_content_matches(
+    predicate: Callable[[dict], bool],
+    origin: Optional[str] = None,
+) -> "Condition":
     """True cuando el ``content`` de la última entry cumple el ``predicate``.
 
     Devuelve ``False`` si el History está vacío. Si el predicado mismo
     falla, la excepción propaga (es bug del predicado, no del helper).
+
+    Args:
+        origin: si está set, filtra por ``content["origin"]`` antes de
+            evaluar — correcto en multi-loop.
     """
     def cond(history: "History") -> bool:
         entries = history.all()
+        if origin is not None:
+            entries = [e for e in entries
+                       if isinstance(e.content, dict) and e.content.get("origin") == origin]
         if not entries:
             return False
         return bool(predicate(entries[-1].content))
     return cond
 
 
-def when_last_tool_called(name: str) -> "Condition":
+def when_last_tool_called(name: str, origin: Optional[str] = None) -> "Condition":
     """True cuando la última entry ``tool_call`` tiene ``content["name"] == name``.
 
     Útil para el patrón "parar cuando el agente llamó tal tool". Es la
     base del sugar ``stop_tool`` en ``InstantLoop``.
 
-    Devuelve ``False`` si no hay entries ``tool_call`` aún en el History,
-    o si la última tool_call fue una distinta.
+    Devuelve ``False`` si no hay entries ``tool_call`` en el History
+    (o en el origin dado), o si la última fue una tool distinta.
 
     Args:
         name: nombre exacto de la tool (case-sensitive).
+        origin: si está set, considera solo tool_calls con
+            ``content["origin"] == origin`` — correcto en multi-loop.
     """
     def cond(history: "History") -> bool:
         tool_calls = history.by_type("tool_call")
+        if origin is not None:
+            tool_calls = [t for t in tool_calls
+                          if isinstance(t.content, dict) and t.content.get("origin") == origin]
         if not tool_calls:
             return False
-        last = tool_calls[-1]
-        return last.content.get("name") == name
+        return tool_calls[-1].content.get("name") == name
     return cond
 
 
@@ -153,9 +182,16 @@ def when_tokens_above(
 # Si no usás un Loop con esa convención, estas conditions devuelven False.
 # ════════════════════════════════════════════════════════════════════
 
-def _last_step_num(history: "History") -> Optional[int]:
-    """Devuelve el step_num de la última entry tipo step_start, o None."""
+def _last_step_num(history: "History", origin: Optional[str] = None) -> Optional[int]:
+    """Devuelve el step_num de la última entry tipo step_start, o None.
+
+    Args:
+        origin: si está set, considera solo step_starts de ese origin.
+    """
     entries = history.by_type("step_start")
+    if origin is not None:
+        entries = [e for e in entries
+                   if isinstance(e.content, dict) and e.content.get("origin") == origin]
     if not entries:
         return None
     last = entries[-1]
@@ -165,7 +201,7 @@ def _last_step_num(history: "History") -> Optional[int]:
     return step_num
 
 
-def every_n_steps(n: int) -> "Condition":
+def every_n_steps(n: int, origin: Optional[str] = None) -> "Condition":
     """True cuando el último ``step_num`` es múltiplo de ``n``.
 
     Requiere que el Loop appendea entries ``type="step_start"`` con
@@ -175,23 +211,31 @@ def every_n_steps(n: int) -> "Condition":
     ``step_num = 0`` se considera múltiplo de cualquier ``n`` (False
     matemáticamente para algunos n; aquí devolvemos False también para
     evitar confusión: la "primera pasada" no debería disparar la rule).
+
+    Args:
+        origin: si está set, considera solo step_starts de ese origin —
+            correcto en multi-loop. ``None`` (default) evalúa sobre
+            todos los step_starts del History.
     """
     def cond(history: "History") -> bool:
-        step_num = _last_step_num(history)
+        step_num = _last_step_num(history, origin=origin)
         if step_num is None or step_num <= 0:
             return False
         return step_num % n == 0
     return cond
 
 
-def at_step(k: int) -> "Condition":
+def at_step(k: int, origin: Optional[str] = None) -> "Condition":
     """True cuando el último ``step_num`` es exactamente ``k``.
 
     Misma convención que ``every_n_steps``: depende de que el Loop
     emita entries de tipo ``step_start`` con ``content["step_num"]``.
+
+    Args:
+        origin: si está set, considera solo step_starts de ese origin.
     """
     def cond(history: "History") -> bool:
-        return _last_step_num(history) == k
+        return _last_step_num(history, origin=origin) == k
     return cond
 
 

--- a/tests/integration/test_after_pr8.py
+++ b/tests/integration/test_after_pr8.py
@@ -191,8 +191,8 @@ def test_view_renders_user_prompt_and_response() -> None:
     loop = InstantLoop(agent=Agent(), name="t", max_steps=2)
     # Inspeccionar lo que la vista produciría al inicio del step 2
     loop.run("query inicial")
-    # Después del run, podemos exportar la vista para ver el último estado
-    rendered = loop.history.export("loop_default")
+    # Después del run, exportamos via loop.view (nombre único del loop)
+    rendered = loop.history.export(loop.view)
     assert isinstance(rendered, RenderedPrompt)
     text = rendered.text
     assert "query inicial" in text

--- a/tests/loop/test_instant_loop.py
+++ b/tests/loop/test_instant_loop.py
@@ -147,19 +147,28 @@ def test_construct_view_unknown_raises() -> None:
 
 
 def test_construct_auto_registers_loop_default_view() -> None:
+    """El Loop registra una vista con nombre único (loop_default_{name}),
+    no el genérico "loop_default" — evita colisiones en multi-loop."""
     h = History()
+    loop = InstantLoop(agent=_mk_mock_agent(), history=h)
+    # La vista registrada es la del loop específico, no la genérica.
+    assert h.has_view(loop.view)
+    assert loop.view.startswith("loop_default_")
+    # El nombre genérico "loop_default" no se registra en el History.
     assert not h.has_view("loop_default")
-    InstantLoop(agent=_mk_mock_agent(), history=h)
-    assert h.has_view("loop_default")
 
 
 def test_construct_does_not_overwrite_existing_view() -> None:
-    """Si el History ya tiene 'loop_default', el Loop NO la pisa."""
+    """Si el History tiene una vista custom 'loop_default', el Loop NO la pisa.
+
+    El Loop registra su propia vista bajo 'loop_default_{name}' — nombre
+    distinto — así que la custom del usuario queda intacta.
+    """
     h = History()
     sentinel = lambda hist: "CUSTOM"
     h.add_view("loop_default", sentinel)
     InstantLoop(agent=_mk_mock_agent(), history=h)
-    # La vista sigue siendo la custom
+    # La vista custom sigue siendo la del usuario
     assert h.export("loop_default") == "CUSTOM"
 
 

--- a/tests/smoke/smoke_multiloop.py
+++ b/tests/smoke/smoke_multiloop.py
@@ -1,0 +1,182 @@
+"""Prueba manual del aislamiento de vistas en multi-loop.
+
+Dos InstantLoops sobre el mismo History. Verifica que:
+- Cada loop solo ve sus propias entries en su vista.
+- Correr loop B no contamina la vista de loop A.
+- El History compartido tiene entries de ambos en orden temporal.
+- Un Monitor con origin ve solo los steps de su loop.
+
+Sin red ni LLM — usa agente mock.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from instantneo.history import History
+from instantneo.loop import InstantLoop
+from instantneo.monitor import Monitor
+from instantneo.monitor.conditions import every_n_steps, when_last_tool_called
+from instantneo.monitor.actions import stop_signal
+
+
+# ── Mock agent ────────────────────────────────────────────────────────
+
+def _mk_agent(name: str, responses: list[str]):
+    """Agente mock que devuelve respuestas prefijadas con su nombre."""
+    class _Agent:
+        def __init__(self):
+            self.config = SimpleNamespace(
+                provider="mock", model="mock-m", api_key="x",
+                role_setup="x", temperature=None, max_tokens=None,
+                presence_penalty=None, frequency_penalty=None,
+                stop=None, seed=None, stream=False, logit_bias=None,
+                images=None, image_detail=None,
+                location=None, service_account_file=None,
+            )
+            self.capabilities = SimpleNamespace(get_schemas=lambda: [])
+            self.last_run = None
+            self._idx = 0
+
+        def get_resolved_role_setup(self, shelf_context=None):
+            return "mock"
+
+        def run(self, prompt, images=None, image_detail=None):
+            resp = responses[self._idx % len(responses)]
+            self._idx += 1
+            self.last_run = SimpleNamespace(
+                error=None, prompt=prompt,
+                response_content=f"[{name}] {resp}",
+                reasoning=None, finish_reason="stop",
+                usage={"input_tokens": 5, "output_tokens": 3,
+                       "total_tokens": 8, "reasoning_tokens": 0},
+                duration_ms=1.0, provider="mock", model="mock-m",
+                timestamp="2026-01-01T00:00:00Z",
+                run_params={"model": "mock-m"},
+                provider_timing=None,
+                llm_calls=[], tool_executions=[], messages_sent=[],
+            )
+    return _Agent()
+
+
+# ── Helpers de validación ─────────────────────────────────────────────
+
+def check(label: str, condition: bool):
+    status = "✅" if condition else "❌"
+    print(f"  {status}  {label}")
+    if not condition:
+        raise AssertionError(f"FALLÓ: {label}")
+
+
+# ── Prueba principal ──────────────────────────────────────────────────
+
+def main():
+    print("\n=== SMOKE TEST: multi-loop view isolation ===\n")
+
+    history = History(name="shared")
+
+    agent_a = _mk_agent("A", ["respuesta A1", "respuesta A2", "respuesta A3"])
+    agent_b = _mk_agent("B", ["respuesta B1", "respuesta B2"])
+
+    mon_a = Monitor(name="mon_a")
+    mon_a.add_rule(every_n_steps(2, origin="loop_a"), stop_signal("loop_a done"))
+
+    mon_b = Monitor(name="mon_b")
+    mon_b.add_rule(every_n_steps(1, origin="loop_b"), stop_signal("loop_b done"))
+
+    loop_a = InstantLoop(
+        agent=agent_a,
+        history=history,
+        name="loop_a",
+        monitors=mon_a,
+        stop_signals=["loop_a done"],
+        max_steps=5,
+    )
+
+    loop_b = InstantLoop(
+        agent=agent_b,
+        history=history,
+        name="loop_b",
+        monitors=mon_b,
+        stop_signals=["loop_b done"],
+        max_steps=5,
+    )
+
+    # ── Verificar registro de vistas ──────────────────────────────
+    print("── Registro de vistas ──")
+    check("loop_a registra 'loop_default_loop_a'",   history.has_view("loop_default_loop_a"))
+    check("loop_b registra 'loop_default_loop_b'",   history.has_view("loop_default_loop_b"))
+    check("NO existe 'loop_default' genérico",        not history.has_view("loop_default"))
+    check("loop.view de A tiene prefix correcto",    loop_a.view == "loop_default_loop_a")
+    check("loop.view de B tiene prefix correcto",    loop_b.view == "loop_default_loop_b")
+    print()
+
+    # ── Correr loop A ─────────────────────────────────────────────
+    print("── Run loop A (para en step 2 por monitor) ──")
+    result_a = loop_a.run("tarea de A")
+    print(f"  terminated_reason: {result_a.terminated_reason}")
+    print(f"  stop_reason:       {result_a.stop_reason}")
+    print(f"  total_steps:       {result_a.total_steps}")
+    print()
+
+    # La vista de A solo debe ver entries de loop_a
+    vista_a = history.export("loop_default_loop_a").text
+    check("vista A contiene respuestas de A",    "[A]" in vista_a)
+    check("vista A NO contiene respuestas de B", "[B]" not in vista_a)
+
+    entries_a_antes = len(history.all())
+    print(f"  entries en history hasta ahora: {entries_a_antes}")
+    print()
+
+    # ── Correr loop B ─────────────────────────────────────────────
+    print("── Run loop B (para en step 1 por monitor) ──")
+    result_b = loop_b.run("tarea de B")
+    print(f"  terminated_reason: {result_b.terminated_reason}")
+    print(f"  stop_reason:       {result_b.stop_reason}")
+    print(f"  total_steps:       {result_b.total_steps}")
+    print()
+
+    # La vista de B solo debe ver entries de loop_b
+    vista_b = history.export("loop_default_loop_b").text
+    check("vista B contiene respuestas de B",    "[B]" in vista_b)
+    check("vista B NO contiene respuestas de A", "[A]" not in vista_b)
+
+    # La vista de A después de correr B no debe haber cambiado
+    vista_a_post = history.export("loop_default_loop_a").text
+    check("vista A no se contamina tras correr B", vista_a == vista_a_post)
+
+    entries_total = len(history.all())
+    print(f"  entries totales en history compartido: {entries_total}")
+    print()
+
+    # ── History compartido tiene entries de ambos ─────────────────
+    print("── History compartido ──")
+    origins = {e.content.get("origin") for e in history.all()
+               if isinstance(e.content, dict) and "origin" in e.content}
+    check("history tiene entries de loop_a", "loop_a" in origins)
+    check("history tiene entries de loop_b", "loop_b" in origins)
+
+    responses_a = history.by_type("response")
+    texts = [e.content.get("text", "") for e in responses_a]
+    check("history tiene respuestas de A y B intercaladas en orden",
+          any("[A]" in t for t in texts) and any("[B]" in t for t in texts))
+    print()
+
+    # ── Segundo run de A: no contamina con run anterior de B ──────
+    print("── Segundo run de A ──")
+    result_a2 = loop_a.run("segunda tarea de A")
+    vista_a2 = history.export("loop_default_loop_a").text
+    check("segunda vista A tiene contenido de ambos runs de A",
+          "tarea de A" in vista_a2 and "segunda tarea de A" in vista_a2)
+    check("segunda vista A sigue sin contenido de B", "[B]" not in vista_a2)
+    print(f"  total_steps run 2 de A: {result_a2.total_steps}")
+    print()
+
+    print("=== TODAS LAS VERIFICACIONES PASARON ✅ ===\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Cada InstantLoop ahora registra su vista bajo un nombre único (loop_default_{name}) con origin baked-in en el closure, evitando colisiones cuando varios loops comparten el mismo History.

- loop_default() recibe origin opcional: filtra por content["origin"] en vez de current_run_id() cuando está set — concurrent-safe
- _build_loop_default_view(origin) propaga el origin al closure
- InstantLoop.__init__ transforma view="loop_default" a "loop_default_{self.name}" antes de registrar
- _ensure_view_available registra con origin=self.name baked-in
- Conditions with_last_is_type/author/content_matches, when_last_tool_called, every_n_steps, at_step y _last_step_num reciben origin=None opcional para filtrar en escenarios multi-loop
- Test actualizado para reflejar el nuevo naming de vistas